### PR TITLE
fix(cmake): optional baseline_walking_controller handling to avoid hard build failures when not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 set(CXX_DISABLE_WERROR 1)
 set(CMAKE_CXX_STANDARD 17)
@@ -14,7 +14,12 @@ if(NOT TARGET mc_rtc::mc_control)
   find_package(mc_rtc REQUIRED)
 endif()
 # Pin BWC to a known-good minimum. Bump when validated against a newer release.
-find_package(baseline_walking_controller 0.1.0 REQUIRED)
+# find_package(baseline_walking_controller 0.1.0 QUIET)
+find_package(baseline_walking_controller 0.1.0 QUIET)
+if(NOT baseline_walking_controller_FOUND)
+  message(WARNING "baseline_walking_controller not found -- skipping grasp-fsm example")
+  return()
+endif()
 
 add_subdirectory(src)
 


### PR DESCRIPTION
Solved cmake error: 

---

CMake Error at examples/grasp-fsm/CMakeLists.txt:17 (find_package):
  By not providing "Findbaseline_walking_controller.cmake" in
  CMAKE_MODULE_PATH this project has asked CMake to find a package
  configuration file provided by "baseline_walking_controller", but CMake did
  not find one.

  Could not find a package configuration file provided by
  "baseline_walking_controller" (requested version 0.1.0) with any of the
  following names:

    baseline_walking_controller.cps
    baseline_walking_controllerConfig.cmake
    baseline_walking_controller-config.cmake

  Add the installation prefix of "baseline_walking_controller" to
  CMAKE_PREFIX_PATH or set "baseline_walking_controller_DIR" to a directory
  containing one of the above files.  If "baseline_walking_controller"
  provides a separate development package or SDK, be sure it has been
  installed.

---
